### PR TITLE
update instructions for bandd tx staking delegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ will return all the system validators, and you can get odinvaloper... address th
 
 ```bash
 bandd tx staking delegate \
-    --validator-addr <validator-operator-address> \ 
-    --amount <your-amount-to-delegate>loki \
+    <validator-operator-address> \
+    <your-amount-to-delegate>loki \
     --from <your-wallet-name> \
     --chain-id odin-testnet-vale \
     --node http://34.77.171.169:26657


### PR DESCRIPTION
I don't think the flags `--validator-addr` and` --amount` are needed for this command.
If I run `bandd tx staking delegate --help` address and amount are the first two arguments, without having any flags.